### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The ROKOStickers framework provides a means for taking photos, dressing them up 
 
 ###Configure your Xcode Project
 
-There are two ways to configure Xcode project: manual and via Cocoapods.
+There are two ways to configure Xcode project: manual and via CocoaPods.
 
-#### Cocoapods
+#### CocoaPods
 Add the following line to your pod file:
 ```
 pod 'ROKO.Mobi.Debug', :configurations => ['Debug']


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
